### PR TITLE
Add missing packages to setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version=equals.__version__,
     author='Todd Sifleet',
     author_email='todd.siflet@gmail.com',
-    packages=['equals', 'equals.constraints'],
+    packages=['equals', 'equals.constraints', 'equals.constraints.numbers', 'equals.constraints.strings'],
     zip_safe=True,
     license='MIT',
     url='https://github.com/toddsifleet/equals',


### PR DESCRIPTION
When installing from pypi the package does not include any files under `equals.constraints.numbers` or `equals.constraints.strings`, this PR fixes that.